### PR TITLE
Feature#7 Optionally generate fake info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'devise-i18n'
 # Object-based searching
 gem 'ransack', github: 'activerecord-hackery/ransack'
 gem 'acts_as_votable'
+# generate fake data
+gem 'faker'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
       devise (>= 4.7.1)
     diff-lcs (1.4.4)
     erubi (1.10.0)
+    faker (2.18.0)
+      i18n (>= 1.6, < 2)
     ffi (1.15.1)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
@@ -260,6 +262,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   devise
   devise-i18n
+  faker
   figaro
   jbuilder (~> 2.7)
   letter_opener

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -118,7 +118,7 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = { host: ENV['APP_HOST'] }
-  config.action_mailer.delivery_method = :smpt
+  config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     user_name:      ENV['SENDMAIL_USERNAME'],
     password:       ENV['SENDMAIL_PASSWORD'],

--- a/db/seeds/optionals/fake_info.rb
+++ b/db/seeds/optionals/fake_info.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+puts 'Generating fake data...'
+
+50.times do |number|
+  if number == 0
+    puts 'Generating admin user admin@email.com with password 123456...'
+    user = User.create!(username: 'Admin user',
+                         email: 'admin@email.com',
+                         password: '123456',
+                         confirmed_at: DateTime.now,
+                         user_type: 'administrator')
+
+    Settlement.all.each do |settlement|
+      InterestPlace.create!(settlement_id: settlement.id, postal_id: settlement.postal.id, user_id: user.id)
+    end
+  else
+    puts 'Generating user...'
+    username = Faker::Name.unique.first_name
+    email = Faker::Internet.unique.email
+    user = User.create!(username: username, email: email, password: '123456', confirmed_at: DateTime.now)
+
+    Settlement.limit(20).each do |settlement|
+      InterestPlace.create!(settlement_id: settlement.id, postal_id: settlement.postal.id, user_id: user.id)
+    end
+  end
+
+  puts 'Generating complaints for user...'
+  10.times do
+    category = Category.find(Category.ids.sample)
+    category_id = category.id
+
+    date_of_events = Faker::Date.between(from: 4.years.ago, to: Date.today)
+
+    state = State.find(State.ids.sample)
+    state_id = state.id
+
+    municipality = state.municipalities.find(state.municipalities.ids.sample)
+    municipality_id = municipality.id
+
+    postal = municipality.postals.find(municipality.postals.ids.sample)
+    postal_id = postal.id
+
+    settlement = postal.settlements.find(postal.settlements.ids.sample)
+    settlement_id = settlement.id
+
+    street = Faker::Address.street_name
+    number = Faker::Address.secondary_address
+
+    title = "#{category.name} en la colonia #{settlement.name}"
+    description = Faker::Quote.matz
+
+    Complaint.create!(user_id: user.id,
+                      category_id: category_id,
+                      date_of_events: date_of_events,
+                      state_id: state_id,
+                      municipality_id: municipality_id,
+                      postal_id: postal_id,
+                      settlement_id: settlement_id,
+                      street: street,
+                      number: number,
+                      title: title,
+                      description: description)
+  end
+end

--- a/lib/tasks/custom_seeds.rake
+++ b/lib/tasks/custom_seeds.rake
@@ -1,0 +1,10 @@
+namespace :db do
+  namespace :seed do
+    Dir[File.join(Rails.root, 'db', 'seeds', 'optionals', '*.rb')].each do |filename|
+      task_name = File.basename(filename, '.rb').intern    
+      task task_name => :environment do
+        load(filename) if File.exist?(filename)
+      end
+    end
+  end
+end

--- a/setup/README.md
+++ b/setup/README.md
@@ -7,3 +7,18 @@ You need to declare these global variables in your system in order to deploy cor
 - MAIL_HOST: the host of the mail account ex. 'gmail.com'.
 
 **NOTE:** If you use a gmail account to send your emails you may have to enable the 'less secure apps' on your Google Account. You can do it in [here](https://myaccount.google.com/lesssecureapps?pli=1).
+
+
+# Generating fake data 
+If you want to generate fake data to fill in with fake random records the models users, places of interest, and complaints you can run after the initialitation of database, the following command in console:
+```bash
+rails db:seed:fake_info
+```
+It can be useful to see the app in action and test all the functionality.
+Then you can access with the following credentials:
+- email: admin@email.com 
+- password: 123456 (the same for all generated users).
+
+
+# Demo app
+Yo can access to a live demonstration of this app hosted on heroku in the following link: [Denuncia ciudadana team03](https://denuncia-ciudadana-team03.herokuapp.com/)


### PR DESCRIPTION
# Description 
Add functionality to generate fake data in the models users, places of interest and complaints.
- Add task to run optional seeds.
- Add faker gem.
- Add seed file to generate random data.
- Update README.md file with feature info.

See issue #7 for details.

# Test 
To generate random data run:
```bash
rails db:seed:fake_info
```